### PR TITLE
Python3 uge support

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
+
 # This script creates a virtual Python environment in ./python-env with all required libraries set up.
 # To use it, call Python at ./python-env/bin/python.
 
 # Test if everything is available
+python3 --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python3 is required but it's not installed.\n"
 virtualenv --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python virtualenv is required but it's not installed.\n"
 gcc --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GCC is required but it's not installed.\n"
 git --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GIT is required but it's not installed.\n"
+
 
 # Report errors if any
 if [[ -n "$missing" ]]; then
@@ -15,5 +18,12 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
-virtualenv python_env
-./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm
+
+# get the python3 interpreter, virtualenv uses python2 by default
+pypath=`which python3`
+
+# get the uap directory
+dir=`dirname $0`
+
+virtualenv --python=$pypath $dir/python_env
+$dir/python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/cluster/cluster-specific-commands.yaml
+++ b/cluster/cluster-specific-commands.yaml
@@ -31,7 +31,7 @@ qstat:
     array_job: ['-t', '1-%s']
     array_job_wquota: ['-t', '1-%s', '-tc', '%s']
     array_out_index: '$TASK_ID'
-    array_task_id: 'SGE_TASK_ID'
+    array_task_id: '((SGE_TASK_ID-1))'
     set_job_name: '-N'
     set_stderr: '-e'
     set_stdout: '-o'


### PR DESCRIPTION
Hi,

as we discussed on the telephone a few weeks ago, I'd like to merge the bootstrap.sh update.
This update contains the python3 requirement to run virtualenv.
The merge request also contains a small change in the culster-specific-commands.yaml file, regarding the SGE_TASK_ID to start counting with 0.